### PR TITLE
MiyooMini: Aspect & Integer scaling hotkey improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ OS = Linux
 TARGET = $(PACKAGE_NAME)
 
 OBJ :=
+OBJ += miyoo.o
 LINK := $(CXX)
 DEF_FLAGS := -marm -mtune=cortex-a7 -march=armv7ve+simd -mfpu=neon-vfpv4 -mfloat-abi=hard -ffast-math -fomit-frame-pointer
 DEF_FLAGS += -ffunction-sections -fdata-sections
@@ -127,7 +128,7 @@ DEF_FLAGS += -I. -Ideps -Ideps/stb -DMIYOOMINI -DDINGUX -MMD
 DEF_FLAGS += -Wall -Wno-unused-function -Wno-unused-variable $(LTO)
 DEF_FLAGS += -std=gnu99 -D_GNU_SOURCE
 LIBS := -ldl -lz -lrt -pthread -lmi_sys -lmi_gfx -lmi_ao -lmi_common
-CFLAGS := 
+CFLAGS :=
 CXXFLAGS := -fno-exceptions -fno-rtti -std=c++11 -D__STDC_CONSTANT_MACROS
 ASFLAGS :=
 LDFLAGS := -Wl,--gc-sections -s

--- a/miyoo.c
+++ b/miyoo.c
@@ -1,0 +1,41 @@
+#if defined(MIYOOMINI)
+
+#include "miyoo.h"
+#include "gfx/video_driver.h"
+#include "configuration.h"
+#include "runloop.h"
+#include "file_path_special.h"
+
+static void show_miyoo_fullscreen_notification(settings_t* settings){
+   char msg[80];
+   struct retro_message_ext msg_obj = {0};
+
+   msg[0] = '\0';
+
+   snprintf(msg, sizeof(msg), "Aspect: %s. %s.",
+      settings->bools.video_dingux_ipu_keep_aspect ? "Original" : "4:3",
+      settings->bools.video_scale_integer ? "1x Scale" : "Screen Fill");
+
+   msg_obj.msg      = msg;
+   msg_obj.duration = 1000;
+   msg_obj.priority = 3;
+   msg_obj.level    = RETRO_LOG_INFO;
+   msg_obj.target   = RETRO_MESSAGE_TARGET_ALL;
+   msg_obj.type     = RETRO_MESSAGE_TYPE_STATUS;
+   msg_obj.progress = -1;
+
+   runloop_environment_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg_obj);
+}
+
+void miyoo_event_fullscreen_impl(settings_t* settings){
+   /* Toggle Aspect & Scaling */
+   settings->bools.video_dingux_ipu_keep_aspect = !settings->bools.video_dingux_ipu_keep_aspect;
+   if (!settings->bools.video_dingux_ipu_keep_aspect) {
+      settings->bools.video_scale_integer = !settings->bools.video_scale_integer;
+   }
+
+   video_driver_apply_state_changes();
+
+   show_miyoo_fullscreen_notification(settings);
+}
+#endif

--- a/miyoo.c
+++ b/miyoo.c
@@ -27,6 +27,42 @@ static void show_miyoo_fullscreen_notification(settings_t* settings){
    runloop_environment_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg_obj);
 }
 
+static void write_core_override_aspect_scale(settings_t* settings){
+   char override_path[PATH_MAX_LENGTH] = {0};
+   char config_directory[PATH_MAX_LENGTH] = {0};
+   config_file_t* conf = NULL;
+
+   /* Used to get running core */
+   rarch_system_info_t* system = &runloop_state_get_ptr()->system;
+
+   /* Get base config directory */
+   fill_pathname_application_special(config_directory,
+         sizeof(config_directory),
+         APPLICATION_SPECIAL_DIRECTORY_CONFIG);
+
+   /* Get override file path - Core Override */
+   fill_pathname_join_special_ext(override_path,
+                  config_directory, system->info.library_name,
+                  system->info.library_name,
+                  FILE_PATH_CONFIG_EXTENSION,
+                  sizeof(override_path));
+
+   // Use existing override file, if exists, or create new config file
+   if (!(conf = config_file_new_from_path_to_string(override_path)))
+         conf = config_file_new_alloc();
+
+   // Set the two overrides - leave everything else as-is
+   config_set_string(conf, "video_dingux_ipu_keep_aspect",
+      (settings->bools.video_dingux_ipu_keep_aspect) ? "true" : "false");
+
+   config_set_string(conf, "video_scale_integer",
+      (settings->bools.video_scale_integer) ? "true" : "false");
+
+   // Write override file
+   bool ret = config_file_write(conf, override_path, false);
+   config_file_free(conf);
+}
+
 void miyoo_event_fullscreen_impl(settings_t* settings){
    /* Toggle Aspect & Scaling */
    settings->bools.video_dingux_ipu_keep_aspect = !settings->bools.video_dingux_ipu_keep_aspect;
@@ -37,5 +73,6 @@ void miyoo_event_fullscreen_impl(settings_t* settings){
    video_driver_apply_state_changes();
 
    show_miyoo_fullscreen_notification(settings);
+   write_core_override_aspect_scale(settings);
 }
 #endif

--- a/miyoo.c
+++ b/miyoo.c
@@ -28,6 +28,10 @@ static void show_miyoo_fullscreen_notification(settings_t* settings){
 }
 
 static void write_core_override_aspect_scale(settings_t* settings){
+   // Saves the Aspect and Scaling settings to the core override file
+   // It will use an existing file if it exists, otherwise a new one will be created
+   // This logic is modified from `configuration.c::config_save_overrides()`.
+
    char override_path[PATH_MAX_LENGTH] = {0};
    char config_directory[PATH_MAX_LENGTH] = {0};
    config_file_t* conf = NULL;

--- a/miyoo.h
+++ b/miyoo.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined(MIYOOMINI)
+
+#include "configuration.h"
+
+void miyoo_event_fullscreen_impl(settings_t* settings);
+
+#endif

--- a/retroarch.c
+++ b/retroarch.c
@@ -211,6 +211,10 @@
 #include "lakka.h"
 #endif
 
+#if defined(MIYOOMINI)
+#include "miyoo.h"
+#endif
+
 #define _PSUPP(var, name, desc) printf("  %s:\n\t\t%s: %s\n", name, desc, var ? "yes" : "no")
 
 #define FAIL_CPU(simd_type) do { \
@@ -2085,29 +2089,6 @@ bool is_accessibility_enabled(bool accessibility_enable, bool accessibility_enab
 }
 #endif
 
-#if defined(MIYOOMINI)
-static inline void show_miyoo_fullscreen_notification(settings_t* settings){
-   char msg[80];
-   struct retro_message_ext msg_obj = {0};
-
-   msg[0] = '\0';
-
-   snprintf(msg, sizeof(msg), "Aspect: %s. %s.",
-      settings->bools.video_dingux_ipu_keep_aspect ? "Original" : "4:3",
-      settings->bools.video_scale_integer ? "1x Scale" : "Screen Fill");
-
-   msg_obj.msg      = msg;
-   msg_obj.duration = 1000;
-   msg_obj.priority = 3;
-   msg_obj.level    = RETRO_LOG_INFO;
-   msg_obj.target   = RETRO_MESSAGE_TARGET_ALL;
-   msg_obj.type     = RETRO_MESSAGE_TYPE_STATUS;
-   msg_obj.progress = -1;
-
-   runloop_environment_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg_obj);
-}
-#endif
-
 /**
  * command_event:
  * @cmd                  : Event command index.
@@ -3781,13 +3762,7 @@ bool command_event(enum event_command cmd, void *data)
 #endif
       case CMD_EVENT_FULLSCREEN_TOGGLE:
 #if defined(MIYOOMINI)
-         settings->bools.video_dingux_ipu_keep_aspect = !settings->bools.video_dingux_ipu_keep_aspect;
-         if (!settings->bools.video_dingux_ipu_keep_aspect) {
-            settings->bools.video_scale_integer = !settings->bools.video_scale_integer;
-         }
-         video_driver_apply_state_changes();
-
-         show_miyoo_fullscreen_notification(settings);
+         miyoo_event_fullscreen_impl(settings);
 #else
          {
             audio_driver_state_t

--- a/retroarch.c
+++ b/retroarch.c
@@ -2085,6 +2085,29 @@ bool is_accessibility_enabled(bool accessibility_enable, bool accessibility_enab
 }
 #endif
 
+#if defined(MIYOOMINI)
+static inline void show_miyoo_fullscreen_notification(settings_t* settings){
+   char msg[80];
+   struct retro_message_ext msg_obj = {0};
+
+   msg[0] = '\0';
+
+   snprintf(msg, sizeof(msg), "Aspect Ratio: %s. Integer Scale: %s.",
+      settings->bools.video_dingux_ipu_keep_aspect ? "original" : "4:3",
+      settings->bools.video_scale_integer ? "on" : "off");
+
+   msg_obj.msg      = msg;
+   msg_obj.duration = 1000;
+   msg_obj.priority = 3;
+   msg_obj.level    = RETRO_LOG_INFO;
+   msg_obj.target   = RETRO_MESSAGE_TARGET_ALL;
+   msg_obj.type     = RETRO_MESSAGE_TYPE_NOTIFICATION_ALT;
+   msg_obj.progress = -1;
+
+   runloop_environment_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg_obj);
+}
+#endif
+
 /**
  * command_event:
  * @cmd                  : Event command index.
@@ -3763,6 +3786,8 @@ bool command_event(enum event_command cmd, void *data)
             settings->bools.video_scale_integer = !settings->bools.video_scale_integer;
          }
          video_driver_apply_state_changes();
+
+         show_miyoo_fullscreen_notification(settings);
 #else
          {
             audio_driver_state_t

--- a/retroarch.c
+++ b/retroarch.c
@@ -2092,16 +2092,16 @@ static inline void show_miyoo_fullscreen_notification(settings_t* settings){
 
    msg[0] = '\0';
 
-   snprintf(msg, sizeof(msg), "Aspect Ratio: %s. Integer Scale: %s.",
-      settings->bools.video_dingux_ipu_keep_aspect ? "original" : "4:3",
-      settings->bools.video_scale_integer ? "on" : "off");
+   snprintf(msg, sizeof(msg), "Aspect: %s. %s.",
+      settings->bools.video_dingux_ipu_keep_aspect ? "Original" : "4:3",
+      settings->bools.video_scale_integer ? "1x Scale" : "Screen Fill");
 
    msg_obj.msg      = msg;
    msg_obj.duration = 1000;
    msg_obj.priority = 3;
    msg_obj.level    = RETRO_LOG_INFO;
    msg_obj.target   = RETRO_MESSAGE_TARGET_ALL;
-   msg_obj.type     = RETRO_MESSAGE_TYPE_NOTIFICATION_ALT;
+   msg_obj.type     = RETRO_MESSAGE_TYPE_STATUS;
    msg_obj.progress = -1;
 
    runloop_environment_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg_obj);


### PR DESCRIPTION
## Description

* Displays a status message when toggling aspect ratio / scaling as described here: https://github.com/libretro/RetroArch/issues/14495
* Plays nicely when showing the FPS on-screen.
* Saves the new aspect / scaling values to the CORE OVERRIDE file - creating one if it doesn't already exist. This will not overwrite any existing overrides - it only updates the override file with the new values.
You can test the changes by toggling the (menu + start) key and seeing the OSD notification. Once satisfied with the setting, you can leave the emulation. When you return, the aspect / scaling setting will remain.


Tested on miyoo354, not 283 (Don't have one)

## Related Issues

Implements: https://github.com/OnionUI/Onion/issues/774

## Reviewers

@schmurtzm

### Demo


https://github.com/OnionUI/RetroArch/assets/9194658/96516de9-d46d-4e16-8389-811a95789152


