### PR TITLE
Fix for a better looking 6x10 Russian font

### DIFF
--- a/gfx/drivers_font_renderer/bitmapfont_6x10.c
+++ b/gfx/drivers_font_renderer/bitmapfont_6x10.c
@@ -45,6 +45,11 @@
 #define FONT_6X10_GLYPH_MIN_LSE 0x100
 #define FONT_6X10_GLYPH_MAX_LSE 0x24F
 
+#define FONT_6X10_FILE_RUS "bitmap6x10_rus.bin"
+#define FONT_6X10_SIZE_RUS 2432
+#define FONT_6X10_GLYPH_MIN_RUS 0x400
+#define FONT_6X10_GLYPH_MAX_RUS 0x45F
+
 /* Loads a font of the specified language
  * Returns NULL if language is invalid or
  * font file is missing */
@@ -75,7 +80,13 @@ bitmapfont_lut_t *bitmapfont_6x10_load(unsigned language)
 	      glyph_min = FONT_6X10_GLYPH_MIN_ENG;
 	      glyph_max = FONT_6X10_GLYPH_MAX_ENG;
 	      break;
-	      /* All Latin alphabet languages go here */
+	   case RETRO_LANGUAGE_RUSSIAN:
+        font_file = FONT_6X10_FILE_RUS;
+        font_size = FONT_6X10_SIZE_RUS;
+        glyph_min = FONT_6X10_GLYPH_MIN_RUS;
+        glyph_max = FONT_6X10_GLYPH_MAX_RUS;
+        break;
+	   /* All Latin alphabet languages go here */
 	   case RETRO_LANGUAGE_FRENCH:
 	   case RETRO_LANGUAGE_SPANISH:
 	   case RETRO_LANGUAGE_GERMAN:

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -288,11 +288,11 @@ typedef struct
 #ifdef HAVE_LANGEXTRA
       bitmapfont_lut_t *eng_6x10;
       bitmapfont_lut_t *lse_6x10;
+      bitmapfont_lut_t *rus_6x10;
       bitmapfont_lut_t *eng_10x10;
       bitmapfont_lut_t *chn_10x10;
       bitmapfont_lut_t *jpn_10x10;
       bitmapfont_lut_t *kor_10x10;
-      bitmapfont_lut_t *rus_10x10;
 #endif
    } fonts;
 
@@ -1417,6 +1417,11 @@ static void rgui_fonts_free(rgui_t *rgui)
       bitmapfont_free_lut(rgui->fonts.lse_6x10);
       rgui->fonts.lse_6x10 = NULL;
    }
+   
+   if (rgui->fonts.rus_6x10) {
+        bitmapfont_free_lut(rgui->fonts.rus_6x10);
+        rgui->fonts.rus_6x10 = NULL;
+   }
 
    if (rgui->fonts.eng_10x10)
    {
@@ -1440,12 +1445,6 @@ static void rgui_fonts_free(rgui_t *rgui)
    {
       bitmapfont_free_lut(rgui->fonts.kor_10x10);
       rgui->fonts.kor_10x10 = NULL;
-   }
-
-   if (rgui->fonts.rus_10x10)
-   {
-      bitmapfont_free_lut(rgui->fonts.rus_10x10);
-      rgui->fonts.rus_10x10 = NULL;
    }
 #endif
 }
@@ -1520,11 +1519,11 @@ static bool rgui_fonts_init(rgui_t *rgui)
 
       case RETRO_LANGUAGE_RUSSIAN:
       {
-         rgui->fonts.eng_10x10    = bitmapfont_10x10_load(RETRO_LANGUAGE_ENGLISH);
-         rgui->fonts.rus_10x10    = bitmapfont_10x10_load(RETRO_LANGUAGE_RUSSIAN);
+         rgui->fonts.eng_6x10    = bitmapfont_6x10_load(RETRO_LANGUAGE_ENGLISH);
+         rgui->fonts.rus_6x10    = bitmapfont_6x10_load(RETRO_LANGUAGE_RUSSIAN);
 
-         if (!rgui->fonts.eng_10x10 ||
-             !rgui->fonts.rus_10x10)
+         if (!rgui->fonts.eng_6x10 ||
+             !rgui->fonts.rus_6x10)
          {
             rgui_fonts_free(rgui);
             *msg_hash_get_uint(MSG_HASH_USER_LANGUAGE) = RETRO_LANGUAGE_ENGLISH;
@@ -1534,10 +1533,10 @@ static bool rgui_fonts_init(rgui_t *rgui)
             goto english;
          }
 
-         rgui->font_width         = FONT_10X10_WIDTH;
-         rgui->font_height        = FONT_10X10_HEIGHT;
-         rgui->font_width_stride  = FONT_10X10_WIDTH_STRIDE;
-         rgui->font_height_stride = FONT_10X10_HEIGHT_STRIDE;
+         rgui->font_width         = FONT_6X10_WIDTH;
+         rgui->font_height        = FONT_6X10_HEIGHT;
+         rgui->font_width_stride  = FONT_6X10_WIDTH_STRIDE;
+         rgui->font_height_stride = FONT_6X10_HEIGHT_STRIDE;
          rgui->language           = language;
          break;
       }
@@ -3704,8 +3703,8 @@ static void rgui_blit_line_rus(
       uint16_t shadow_color)
 {
    uint16_t *frame_buf_data   = rgui->frame_buf.data;
-   bitmapfont_lut_t *font_eng = rgui->fonts.eng_10x10;
-   bitmapfont_lut_t *font_rus = rgui->fonts.rus_10x10;
+   bitmapfont_lut_t *font_eng = rgui->fonts.eng_6x10;
+   bitmapfont_lut_t *font_rus = rgui->fonts.rus_6x10;
 
    while (!string_is_empty(message))
    {
@@ -3732,19 +3731,19 @@ static void rgui_blit_line_rus(
          else
             continue;
 
-         for (j = 0; j < FONT_10X10_HEIGHT; j++)
+         for (j = 0; j < FONT_6X10_HEIGHT; j++)
          {
             unsigned buff_offset = ((y + j) * fb_width) + x;
 
-            for (i = 0; i < FONT_10X10_WIDTH; i++)
+            for (i = 0; i < FONT_6X10_WIDTH; i++)
             {
-               if (*(symbol_lut + i + (j * FONT_10X10_WIDTH)))
+               if (*(symbol_lut + i + (j * FONT_6X10_WIDTH)))
                   *(frame_buf_data + buff_offset + i) = color;
             }
          }
       }
 
-      x += FONT_10X10_WIDTH_STRIDE;
+      x += FONT_6X10_WIDTH_STRIDE;
    }
 }
 
@@ -3760,8 +3759,8 @@ static void rgui_blit_line_rus_shadow(
    uint16_t color_buf[2];
    uint16_t shadow_color_buf[2];
    uint16_t *frame_buf_data   = rgui->frame_buf.data;
-   bitmapfont_lut_t *font_eng = rgui->fonts.eng_10x10;
-   bitmapfont_lut_t *font_rus = rgui->fonts.rus_10x10;
+   bitmapfont_lut_t *font_eng = rgui->fonts.eng_6x10;
+   bitmapfont_lut_t *font_rus = rgui->fonts.rus_6x10;
 
    color_buf[0]               = color;
    color_buf[1]               = shadow_color;
@@ -3794,13 +3793,13 @@ static void rgui_blit_line_rus_shadow(
          else
             continue;
 
-         for (j = 0; j < FONT_10X10_HEIGHT; j++)
+         for (j = 0; j < FONT_6X10_HEIGHT; j++)
          {
             unsigned buff_offset = ((y + j) * fb_width) + x;
 
-            for (i = 0; i < FONT_10X10_WIDTH; i++)
+            for (i = 0; i < FONT_6X10_WIDTH; i++)
             {
-               if (*(symbol_lut + i + (j * FONT_10X10_WIDTH)))
+               if (*(symbol_lut + i + (j * FONT_6X10_WIDTH)))
                {
                   uint16_t *frame_buf_ptr = frame_buf_data + buff_offset + i;
 
@@ -3815,7 +3814,7 @@ static void rgui_blit_line_rus_shadow(
          }
       }
 
-      x += FONT_10X10_WIDTH_STRIDE;
+      x += FONT_6X10_WIDTH_STRIDE;
    }
 }
 


### PR DESCRIPTION
Default 10x10 Russian font is difficult to read as most of the text goes off screen and scrolling is enabled. Replacing it with a better looking 6x10 font.

Screenshots before:
![RetroArch_001](https://github.com/OnionUI/RetroArch/assets/47685963/ff125360-a614-4ada-90c6-5fdf80d5383c)
![RetroArch_002](https://github.com/OnionUI/RetroArch/assets/47685963/c3961973-94aa-47bb-b689-752eca323832)

Screenshots after:
![RetroArch_000](https://github.com/OnionUI/RetroArch/assets/47685963/9cbd2598-3729-4bd8-8bc0-78e0658b83ae)
![RetroArch_003](https://github.com/OnionUI/RetroArch/assets/47685963/67519035-da66-46f5-9374-0e7012d3761f)

Font file:
[bitmap6x10_rus.zip](https://github.com/OnionUI/RetroArch/files/12837754/bitmap6x10_rus.zip)

Font file based on https://docs.libretro.com/development/retroarch/new-translations/#generating-custom-font-for-rgui

